### PR TITLE
Blacklist Contexts app to remove unuseable windows

### DIFF
--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -271,6 +271,7 @@ function obj:_removeUnuseableWindows(windows)
     -- Other things
     if bundleID == "com.pop.pop.app" and window:title() == "overlay" then return false end
     if bundleID == "us.zoom.xos" and window:title() == "" then return false end
+    if bundleID == "com.contextsformac.Contexts" then return false end
     return true
   end)
 end


### PR DESCRIPTION
Contexts is a window switcher that can replace or augment native OS X command tab functionality
https://contexts.co/